### PR TITLE
BREAKING CHANGE: add task ID segment to local artifact path 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "joinery"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d8bde02bbf44a562cf068a8ff4a68842df387e302a03a4de4a57fcf82ec377"
+
+[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,6 +1254,7 @@ dependencies = [
  "format",
  "futures",
  "indicatif",
+ "joinery",
  "log",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ env_logger = "0.10.0"
 format = "0.2.4"
 futures = { version = "0.3.28", default-features = false, features = ["std"] }
 indicatif = { version = "0.17.6", features = ["futures"] }
+joinery = "3.1.0"
 log = "0.4.20"
 regex = "1.9.4"
 reqwest = { version = "0.11.20", features = ["gzip", "json"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use clap::Parser;
 use format::lazy_format;
 use futures::stream::StreamExt;
 use indicatif::ProgressBar;
+use joinery::JoinableIterator as _;
 use regex::Regex;
 use reqwest::{Client, StatusCode, Url};
 use serde::Deserialize;
@@ -357,14 +358,17 @@ async fn get_artifacts_for_revision(client: &Client, options: &Options, revision
                 return;
             }
 
-            let job_path = format!(
-                "{revision}/{platform}/{platform_option}/{job_group_symbol}/{job_type_symbol}"
-            );
             let local_artifact_path = {
-                let mut path = out_dir.join(job_path);
-                path.push(&this_run_idx.to_string());
-                path.push(artifact_name);
-                path
+                let segments: &[&dyn std::fmt::Display] = &[
+                    revision,
+                    platform,
+                    platform_option,
+                    job_group_symbol,
+                    job_type_symbol,
+                    &this_run_idx,
+                    artifact_name,
+                ];
+                out_dir.join(segments.iter().join_with('/').to_string())
             };
 
             if local_artifact_path.is_file() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,6 +365,7 @@ async fn get_artifacts_for_revision(client: &Client, options: &Options, revision
                     platform_option,
                     job_group_symbol,
                     job_type_symbol,
+                    task_id,
                     &this_run_idx,
                     artifact_name,
                 ];

--- a/src/main.rs
+++ b/src/main.rs
@@ -312,10 +312,6 @@ async fn get_artifacts_for_revision(client: &Client, options: &Options, revision
                 ..
             } = job;
 
-            let job_path = format!(
-                "{revision}/{platform}/{platform_option}/{job_group_symbol}/{job_type_symbol}"
-            );
-
             let this_run_idx: u32;
             {
                 let mut run_counts = run_counts.lock().unwrap();
@@ -361,6 +357,9 @@ async fn get_artifacts_for_revision(client: &Client, options: &Options, revision
                 return;
             }
 
+            let job_path = format!(
+                "{revision}/{platform}/{platform_option}/{job_group_symbol}/{job_type_symbol}"
+            );
             let local_artifact_path = {
                 let mut path = out_dir.join(job_path);
                 path.push(&this_run_idx.to_string());


### PR DESCRIPTION
With 1.0.2/#21, I accidentally swapped the index of "identical" tasks with a run ID, but _removed a distinguishing path segment between different tasks_. The result is that `treeherder-dl` invocations would overwrite artifacts when there was more than a single task based on the same job. Oops! 😳

I don't think a counter-as-an-ID is as useful as the task ID itself. This will significantly lengthen the output path for artifacts, but I think it's the best option.

We cannot avoid a breaking change here; #21 _should_ have been a breaking change, in retrospect, if we had done it correctly.